### PR TITLE
fixes forecast data download

### DIFF
--- a/daemon/Settings.toml
+++ b/daemon/Settings.toml
@@ -1,4 +1,4 @@
-level = "debug"
+level = "info"
 base_url = "http://localhost:9100"
 data_dir = "./data"
 sleep_interval = 3600

--- a/daemon/Settings.toml
+++ b/daemon/Settings.toml
@@ -1,4 +1,4 @@
-level = "info"
+level = "debug"
 base_url = "http://localhost:9100"
 data_dir = "./data"
 sleep_interval = 3600

--- a/daemon/src/domains/forecasts/download_forecast.rs
+++ b/daemon/src/domains/forecasts/download_forecast.rs
@@ -322,13 +322,12 @@ impl TryFrom<Dwml> for HashMap<String, Vec<WeatherForecast>> {
             time_layouts.insert(time_range.first().unwrap().key.clone(), time_range);
         }
 
-        // The `location_key` is the key for each hashmap entry
+        // The `location-key` is the key for each hashmap entry
         let mut weather: HashMap<String, Vec<WeatherForecast>> = HashMap::new();
         let generated_at = get_generated_at(&raw_data);
 
         raw_data.data.location.iter().for_each(|location| {
             let weather_forecast = get_forecasts_ranges(location, generated_at);
-            //need to use station_id
             weather.insert(location.location_key.clone(), weather_forecast);
         });
         // Used to pull the data forward from last time we had a forecast for a value
@@ -731,7 +730,7 @@ impl ForecastService {
                             data.keys()
                         );
                         let mut forecast_data = forecast_data_clone.lock().await;
-                        //change key to station_id
+                        //using station_id as the key
                         forecast_data.extend(data);
                     }
                     Err(err) => {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -72,14 +72,12 @@ async fn process_data(
         .get_forecasts(&city_weather_coordinates)
         .await?;
     debug!(logger_cpy, "forcasts count {}", forecasts.len());
-    debug!(logger_cpy, "forecasts: {:?}", forecasts);
-
     let observation_service = ObservationService::new(logger, fetcher);
     let observations = observation_service
         .get_observations(&city_weather_coordinates)
         .await?;
 
-    debug!(logger_cpy, "observations: {:?}", observations);
+    debug!(logger_cpy, "observations count: {:?}", observations.len());
     let current_utc_time: String = OffsetDateTime::now_utc().format(&Rfc3339)?;
     let root_path = cli.data_dir.clone().unwrap_or(String::from("./data"));
     create_folder(&root_path, logger_cpy);
@@ -88,7 +86,6 @@ async fn process_data(
     if !subfolder_exists(&subfolder) {
         create_folder(&subfolder, logger_cpy)
     }
-    debug!(logger_cpy, "forcasts count {}", forecasts.len());
     let forecast_parquet = save_forecasts(
         forecasts,
         &subfolder,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -71,6 +71,7 @@ async fn process_data(
     let forecasts = forecast_service
         .get_forecasts(&city_weather_coordinates)
         .await?;
+    debug!(logger_cpy, "forcasts count {}", forecasts.len());
     debug!(logger_cpy, "forecasts: {:?}", forecasts);
 
     let observation_service = ObservationService::new(logger, fetcher);
@@ -87,6 +88,7 @@ async fn process_data(
     if !subfolder_exists(&subfolder) {
         create_folder(&subfolder, logger_cpy)
     }
+    debug!(logger_cpy, "forcasts count {}", forecasts.len());
     let forecast_parquet = save_forecasts(
         forecasts,
         &subfolder,

--- a/parquet_file_service/src/startup.rs
+++ b/parquet_file_service/src/startup.rs
@@ -40,7 +40,7 @@ pub fn app(logger: Logger, remote_url: String, ui_dir: String, data_dir: String)
         .route("/files", get(files))
         .route("/file/:file_name", get(download))
         .route("/file/:file_name", post(upload))
-        .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // max is in bytes
+        .layer(DefaultBodyLimit::max(30 * 1024 * 1024)) // max is in bytes
         .route("/", get(index_handler))
         .with_state(Arc::new(app_state))
         .nest_service("/ui", serve_dir.clone())


### PR DESCRIPTION
We were using the location key when we need to use the station_id for the forecasts, this was causing data to overwrite. We now are correctly building the forecast file for all the locations we want.