### PR TITLE
Handle no live events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "oracle"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "oracle"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daemon"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 repository = "https://github.com/tee8z/noaa-data-pipeline"
 

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracle"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 repository = "https://github.com/tee8z/noaa-data-pipeline"
 

--- a/oracle/src/oracle.rs
+++ b/oracle/src/oracle.rs
@@ -296,6 +296,13 @@ impl Oracle {
             " etl_process_id {}, completed getting events to sign",
             etl_process_id
         );
+        if events_to_sign.is_empty() {
+            info!(
+                " etl_process_id {}, no events to sign, completed etl process",
+                etl_process_id
+            );
+            return Ok(());
+        }
         debug!(
             " etl_process_id {}, adding oracle signature to events",
             etl_process_id

--- a/oracle/tests/api/etl_workflow.rs
+++ b/oracle/tests/api/etl_workflow.rs
@@ -17,6 +17,26 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 #[tokio::test]
+async fn can_handle_no_events() {
+    let weather_data = MockWeatherAccess::new();
+    let test_app = spawn_app(Arc::new(weather_data)).await;
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(String::from("/oracle/update"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::empty())
+        .unwrap();
+    let response = test_app
+        .app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("Failed to execute request.");
+    sleep(std::time::Duration::from_secs(1)).await;
+    assert!(response.status().is_success());
+}
+
+#[tokio::test]
 async fn can_get_event_run_etl_and_see_it_signed() {
     let mut weather_data = MockWeatherAccess::new();
     //called twice per ETL process


### PR DESCRIPTION
When doing the ETL process, we need to gracefully handle when there are no events to sign