### PR TITLE
fix units and scoring

### DIFF
--- a/crates/oracle/src/db/event_data.rs
+++ b/crates/oracle/src/db/event_data.rs
@@ -220,7 +220,7 @@ impl EventData {
             .flat_map(|(a, b, c)| vec![a, b.to_string(), c])
             .collect();
 
-        info!("insert values: {:?}", insert_values);
+        debug!("insert values: {:?}", insert_values);
 
         let conn = self.new_write_connection_retry().await?;
         let mut weather_stmt = conn.prepare(&query_str)?;

--- a/crates/oracle/src/db/weather_data.rs
+++ b/crates/oracle/src/db/weather_data.rs
@@ -108,7 +108,7 @@ impl WeatherData for WeatherAccess {
             "MIN(min_temp)".as_("temp_low"),
             "MAX(max_temp)".as_("temp_high"),
             "MAX(wind_speed)".as_("wind_speed"),
-            "FIRST(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
+            "MAX(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
         ))
         .from(format!(
             "read_parquet(['{}'], union_by_name = true)",
@@ -153,7 +153,7 @@ impl WeatherData for WeatherAccess {
                 "MIN(temp_low)".as_("temp_low"),
                 "MAX(temp_high)".as_("temp_high"),
                 "MAX(wind_speed)".as_("wind_speed"),
-                "FIRST(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
+                "MAX(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
             ))
             .from("daily_forecasts")
             .group_by(("station_id", "date"));
@@ -188,7 +188,7 @@ impl WeatherData for WeatherAccess {
             "min(temperature_value)".as_("temp_low"),
             "max(temperature_value)".as_("temp_high"),
             "max(wind_speed)".as_("wind_speed"),
-            "FIRST(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
+            "MAX(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
         ))
         .from(format!(
             "read_parquet(['{}'], union_by_name = true)",

--- a/crates/oracle/src/db/weather_data.rs
+++ b/crates/oracle/src/db/weather_data.rs
@@ -1,4 +1,7 @@
-use crate::{file_access, FileAccess, FileData, FileParams, ForecastRequest, ObservationRequest};
+use crate::{
+    file_access, FileAccess, FileData, FileParams, ForecastRequest, ObservationRequest,
+    TemperatureUnit,
+};
 use async_trait::async_trait;
 use duckdb::{
     arrow::array::{Float64Array, Int64Array, RecordBatch, StringArray},
@@ -40,6 +43,14 @@ pub trait WeatherData: Sync + Send {
         station_ids: Vec<String>,
     ) -> Result<Vec<Observation>, Error>;
     async fn stations(&self) -> Result<Vec<Station>, Error>;
+}
+
+pub fn convert_temperature(value: f64, from_unit: &str, to_unit: &TemperatureUnit) -> f64 {
+    match (from_unit.to_lowercase().as_str(), to_unit) {
+        ("celsius", TemperatureUnit::Fahrenheit) => (value * 9.0 / 5.0) + 32.0,
+        ("fahrenheit", TemperatureUnit::Celsius) => (value - 32.0) * 5.0 / 9.0,
+        _ => value, // No conversion needed
+    }
 }
 
 impl WeatherAccess {
@@ -97,6 +108,7 @@ impl WeatherData for WeatherAccess {
             "MIN(min_temp)".as_("temp_low"),
             "MAX(max_temp)".as_("temp_high"),
             "MAX(wind_speed)".as_("wind_speed"),
+            "FIRST(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
         ))
         .from(format!(
             "read_parquet(['{}'], union_by_name = true)",
@@ -141,19 +153,19 @@ impl WeatherData for WeatherAccess {
                 "MIN(temp_low)".as_("temp_low"),
                 "MAX(temp_high)".as_("temp_high"),
                 "MAX(wind_speed)".as_("wind_speed"),
+                "FIRST(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
             ))
             .from("daily_forecasts")
             .group_by(("station_id", "date"));
 
         let records = self.query(query, values).await?;
-        let forecasts: Forecasts =
-            records
-                .iter()
-                .map(|record| record.into())
-                .fold(Forecasts::new(), |mut acc, obs| {
-                    acc.merge(obs);
-                    acc
-                });
+        let forecasts: Forecasts = records
+            .iter()
+            .map(|record| Forecasts::from_with_temp_unit(record, &req.temperature_unit))
+            .fold(Forecasts::new(), |mut acc, forecast| {
+                acc.merge(forecast);
+                acc
+            });
 
         Ok(forecasts.values)
     }
@@ -176,6 +188,7 @@ impl WeatherData for WeatherAccess {
             "min(temperature_value)".as_("temp_low"),
             "max(temperature_value)".as_("temp_high"),
             "max(wind_speed)".as_("wind_speed"),
+            "FIRST(temperature_unit_code)".as_("temperature_unit_code"), // assumes consistent units per grouping
         ))
         .from(format!(
             "read_parquet(['{}'], union_by_name = true)",
@@ -210,14 +223,13 @@ impl WeatherData for WeatherAccess {
         }
         query = query.group_by("station_id");
         let records = self.query(query, values).await?;
-        let observations: Observations =
-            records
-                .iter()
-                .map(|record| record.into())
-                .fold(Observations::new(), |mut acc, obs| {
-                    acc.merge(obs);
-                    acc
-                });
+        let observations: Observations = records
+            .iter()
+            .map(|record| Observations::from_with_temp_unit(record, &req.temperature_unit))
+            .fold(Observations::new(), |mut acc, obs| {
+                acc.merge(obs);
+                acc
+            });
         Ok(observations.values)
     }
 
@@ -272,21 +284,8 @@ impl Forecasts {
         self.values.extend(forecasts.values);
         self
     }
-}
 
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct Forecast {
-    pub station_id: String,
-    pub date: String,
-    pub start_time: String,
-    pub end_time: String,
-    pub temp_low: i64,
-    pub temp_high: i64,
-    pub wind_speed: i64,
-}
-
-impl From<&RecordBatch> for Forecasts {
-    fn from(record_batch: &RecordBatch) -> Self {
+    fn from_with_temp_unit(record_batch: &RecordBatch, target_unit: &TemperatureUnit) -> Self {
         let mut forecasts = Vec::new();
         let station_id_arr = record_batch
             .column(0)
@@ -324,6 +323,12 @@ impl From<&RecordBatch> for Forecasts {
             .downcast_ref::<Int64Array>()
             .expect("Expected Int64Array in column 6");
 
+        let temperature_unit_code_arr = record_batch
+            .column(7)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Expected StringArray in column 7");
+
         for row_index in 0..record_batch.num_rows() {
             let station_id = station_id_arr.value(row_index).to_owned();
             let date = date_arr.value(row_index).to_owned();
@@ -332,8 +337,9 @@ impl From<&RecordBatch> for Forecasts {
             let temp_low = temp_low_arr.value(row_index);
             let temp_high = temp_high_arr.value(row_index);
             let wind_speed = wind_speed_arr.value(row_index);
+            let temp_unit_code = temperature_unit_code_arr.value(row_index).to_owned();
 
-            forecasts.push(Forecast {
+            let mut forecast = Forecast {
                 station_id,
                 date,
                 start_time,
@@ -341,10 +347,48 @@ impl From<&RecordBatch> for Forecasts {
                 temp_low,
                 temp_high,
                 wind_speed,
-            });
+                temp_unit_code,
+            };
+            forecast.convert_temperature(target_unit);
+            forecasts.push(forecast);
         }
 
         Self { values: forecasts }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct Forecast {
+    pub station_id: String,
+    pub date: String,
+    pub start_time: String,
+    pub end_time: String,
+    pub temp_low: i64,
+    pub temp_high: i64,
+    pub wind_speed: i64,
+    pub temp_unit_code: String,
+}
+
+impl Forecast {
+    pub fn convert_temperature(&mut self, target_unit: &TemperatureUnit) {
+        // Skip if already in the target unit
+        if self.temp_unit_code.to_lowercase() == target_unit.to_string() {
+            return;
+        }
+
+        match (self.temp_unit_code.to_lowercase().as_str(), target_unit) {
+            ("celsius", TemperatureUnit::Fahrenheit) => {
+                self.temp_low = ((self.temp_low as f64) * 9.0 / 5.0 + 32.0) as i64;
+                self.temp_high = ((self.temp_high as f64) * 9.0 / 5.0 + 32.0) as i64;
+                self.temp_unit_code = TemperatureUnit::Fahrenheit.to_string();
+            }
+            ("fahrenheit", TemperatureUnit::Celsius) => {
+                self.temp_low = ((self.temp_low as f64 - 32.0) * 5.0 / 9.0) as i64;
+                self.temp_high = ((self.temp_high as f64 - 32.0) * 5.0 / 9.0) as i64;
+                self.temp_unit_code = TemperatureUnit::Celsius.to_string();
+            }
+            _ => (), // No conversion needed or unknown unit
+        }
     }
 }
 
@@ -361,20 +405,8 @@ impl Observations {
         self.values.extend(observations.values);
         self
     }
-}
 
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct Observation {
-    pub station_id: String,
-    pub start_time: String,
-    pub end_time: String,
-    pub temp_low: f64,
-    pub temp_high: f64,
-    pub wind_speed: i64,
-}
-
-impl From<&RecordBatch> for Observations {
-    fn from(record_batch: &RecordBatch) -> Self {
+    pub fn from_with_temp_unit(record_batch: &RecordBatch, target_unit: &TemperatureUnit) -> Self {
         let mut observations = Vec::new();
         let station_id_arr = record_batch
             .column(0)
@@ -405,7 +437,13 @@ impl From<&RecordBatch> for Observations {
             .column(5)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .expect("Expected Int64Array in column 4");
+            .expect("Expected Int64Array in column 5");
+
+        let temperature_unit_code_arr = record_batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Expected StringArray in column 6");
 
         for row_index in 0..record_batch.num_rows() {
             let station_id = station_id_arr.value(row_index).to_owned();
@@ -414,19 +452,57 @@ impl From<&RecordBatch> for Observations {
             let temp_low = temp_low_arr.value(row_index);
             let temp_high = temp_high_arr.value(row_index);
             let wind_speed = wind_speed_arr.value(row_index);
+            let temp_unit_code = temperature_unit_code_arr.value(row_index).to_owned();
 
-            observations.push(Observation {
+            let mut observation = Observation {
                 station_id,
                 start_time,
                 end_time,
                 temp_low,
                 temp_high,
                 wind_speed,
-            });
+                temp_unit_code,
+            };
+            observation.convert_temperature(target_unit);
+            observations.push(observation);
         }
 
         Self {
             values: observations,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct Observation {
+    pub station_id: String,
+    pub start_time: String,
+    pub end_time: String,
+    pub temp_low: f64,
+    pub temp_high: f64,
+    pub wind_speed: i64,
+    pub temp_unit_code: String,
+}
+
+impl Observation {
+    pub fn convert_temperature(&mut self, target_unit: &TemperatureUnit) {
+        // Skip if already in the target unit
+        if self.temp_unit_code.to_lowercase() == target_unit.to_string() {
+            return;
+        }
+
+        match (self.temp_unit_code.to_lowercase().as_str(), target_unit) {
+            ("celsius", TemperatureUnit::Fahrenheit) => {
+                self.temp_low = (self.temp_low * 9.0) / 5.0 + 32.0;
+                self.temp_high = (self.temp_high * 9.0) / 5.0 + 32.0;
+                self.temp_unit_code = TemperatureUnit::Fahrenheit.to_string();
+            }
+            ("fahrenheit", TemperatureUnit::Celsius) => {
+                self.temp_low = (self.temp_low - 32.0) * 5.0 / 9.0;
+                self.temp_high = (self.temp_high - 32.0) * 5.0 / 9.0;
+                self.temp_unit_code = TemperatureUnit::Celsius.to_string();
+            }
+            _ => (), // No conversion needed or unknown unit
         }
     }
 }

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -404,11 +404,9 @@ impl Oracle {
                 add_only_forecast_data(&event, forecast_data).await?
             } else {
                 let observation_data = self.event_observation_data(&event).await?;
-                info!("above update ksks");
                 add_forecast_data_and_observation_data(&event, forecast_data, observation_data)
                     .await?
             };
-            info!("above update");
             self.event_data
                 .update_weather_station_data(event.id, weather)
                 .await?;

--- a/crates/oracle/src/routes/stations/weather_routes.rs
+++ b/crates/oracle/src/routes/stations/weather_routes.rs
@@ -1,13 +1,13 @@
-use std::sync::Arc;
-
 use ::serde::Deserialize;
 use axum::{
     extract::{Query, State},
     Json,
 };
+use core::fmt;
 use serde::Serialize;
+use std::sync::Arc;
 use time::OffsetDateTime;
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::{AppError, AppState, FileParams, Forecast, Observation, Station};
 
@@ -43,6 +43,8 @@ pub struct ForecastRequest {
     #[serde(default)]
     pub end: Option<OffsetDateTime>,
     pub station_ids: String,
+    #[serde(default)]
+    pub temperature_unit: TemperatureUnit,
 }
 
 impl ForecastRequest {
@@ -74,6 +76,8 @@ pub struct ObservationRequest {
     #[serde(default)]
     pub end: Option<OffsetDateTime>,
     pub station_ids: String,
+    #[serde(default)]
+    pub temperature_unit: TemperatureUnit,
 }
 
 impl ObservationRequest {
@@ -92,6 +96,22 @@ impl From<&ObservationRequest> for FileParams {
             end: value.end,
             observations: Some(true),
             forecasts: Some(false),
+        }
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, ToSchema)]
+pub enum TemperatureUnit {
+    Celsius,
+    #[default]
+    Fahrenheit,
+}
+
+impl fmt::Display for TemperatureUnit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TemperatureUnit::Celsius => write!(f, "celsius"),
+            TemperatureUnit::Fahrenheit => write!(f, "fahrenheit"),
         }
     }
 }

--- a/crates/oracle/tests/api/etl_workflow.rs
+++ b/crates/oracle/tests/api/etl_workflow.rs
@@ -9,7 +9,7 @@ use log::info;
 use nostr_sdk::Keys;
 use oracle::{
     oracle::get_winning_bytes, AddEventEntry, CreateEvent, Event, EventStatus, Forecast,
-    Observation, WeatherChoices,
+    Observation, TemperatureUnit, WeatherChoices,
 };
 use serde_json::from_slice;
 use std::{cmp, sync::Arc};
@@ -286,22 +286,25 @@ async fn can_get_event_run_etl_and_see_it_signed() {
         .iter()
         .find(|entry| entry.id == entry_1.id)
         .unwrap();
-    assert_eq!(entry_1_res.score.unwrap(), 409899);
-    let entry_2_res = entries_scores_order
-        .iter()
-        .find(|entry| entry.id == entry_2.id)
-        .unwrap();
-    assert_eq!(entry_2_res.score.unwrap(), 309799);
+    assert_eq!(entry_1_res.score.unwrap(), 399900);
+
     let entry_3_res = entries_scores_order
         .iter()
         .find(|entry| entry.id == entry_3.id)
         .unwrap();
-    assert_eq!(entry_3_res.score.unwrap(), 409699);
+    assert_eq!(entry_3_res.score.unwrap(), 399700);
+
+    let entry_2_res = entries_scores_order
+        .iter()
+        .find(|entry| entry.id == entry_2.id)
+        .unwrap();
+    assert_eq!(entry_2_res.score.unwrap(), 299800);
+
     let entry_4_res = entries_scores_order
         .iter()
         .find(|entry| entry.id == entry_4.id)
         .unwrap();
-    assert_eq!(entry_4_res.score.unwrap(), 109599);
+    assert_eq!(entry_4_res.score.unwrap(), 99600);
 
     let mut entry_outcome_order = res.entries.clone();
     entry_outcome_order.sort_by_key(|entry| entry.id);
@@ -343,6 +346,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             temp_low: 9,
             temp_high: 35,
             wind_speed: 8,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
         Forecast {
             station_id: String::from("KSAW"),
@@ -352,6 +356,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             temp_low: 17,
             temp_high: 25,
             wind_speed: 3,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
         Forecast {
             station_id: String::from("PAPG"),
@@ -361,6 +366,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             temp_low: 14,
             temp_high: 17,
             wind_speed: 6,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
         Forecast {
             station_id: String::from("KWMC"),
@@ -370,6 +376,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             temp_low: 31,
             temp_high: 33,
             wind_speed: 11,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
     ]
 }
@@ -383,6 +390,7 @@ fn mock_observation_data() -> Vec<Observation> {
             temp_low: 9.4,
             temp_high: 35 as f64,
             wind_speed: 11,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
         Observation {
             station_id: String::from("KSAW"),
@@ -391,6 +399,7 @@ fn mock_observation_data() -> Vec<Observation> {
             temp_low: 22 as f64,
             temp_high: 25 as f64,
             wind_speed: 10,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
         Observation {
             station_id: String::from("PAPG"),
@@ -399,6 +408,7 @@ fn mock_observation_data() -> Vec<Observation> {
             temp_low: 15 as f64,
             temp_high: 16 as f64,
             wind_speed: 6,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
         Observation {
             station_id: String::from("KWMC"),
@@ -407,6 +417,7 @@ fn mock_observation_data() -> Vec<Observation> {
             temp_low: 32.8,
             temp_high: 34.4,
             wind_speed: 11,
+            temp_unit_code: TemperatureUnit::Fahrenheit.to_string(),
         },
     ]
 }


### PR DESCRIPTION
We change the scoring mechanism to be easier to convert from combined raw score + time into just the raw score. Also fix the logic on how it is calculated. Additionally, we fix the unit conversion between forecast and observed data, as they are coming in as two different units from NOAA.

New scoring logic:
```
            let (created_at_secs, created_at_nano) = entry
                .id
                .get_timestamp()
                .expect("UUIDv7 should have timestamp")
                .to_unix();
            let time_millis = (created_at_secs * 1000) + (created_at_nano as u64 / 1_000_000);

            // Scoring logic: score * 10^4 - timestamp
            // Using 4 digits for timestamp (keeping within the 10000 range as before)
            // Limit timestamp to last 4 digits (mod 10000) to maintain consistency with old code
            let timestamp_part = time_millis % 10000;
            let total_score = ((base_score * 10000) - timestamp_part) as i64;

            /* With our formula score * 10^4 - timestamp:
            - Higher base scores will still dominate (primary sorting criterion)
            - For equal scores, earlier entries (smaller timestamps) will result in higher total scores
              which means they'll rank higher when sorting in descending order

            This maintains the original constraints:
            - Up to 10,000 entries over 24h with negligible collision risk
            - Scales well for concurrent entry creation
            - Keeps the amount of possible outcomes for the DLC as low as possible
            */

```
We're able to get the values out by:
```
base_score = total_score / 10000 (integer division, dropping remainder)
timestamp_part = base_score * 10000 - total_score
```
We will display the base_score to the user and use the timestamp_part to order on ties.