### PR TITLE
fix: make elevation_m optional in NOAA observation parsing

### DIFF
--- a/crates/daemon/src/coordinates.rs
+++ b/crates/daemon/src/coordinates.rs
@@ -203,7 +203,7 @@ pub struct Station {
     longitude: String,
 
     #[serde(rename = "elevation_m")]
-    elevation_m: String,
+    elevation_m: Option<String>,
 
     #[serde(rename = "site")]
     site: String,

--- a/crates/daemon/src/domains/observations/xml_observation.rs
+++ b/crates/daemon/src/domains/observations/xml_observation.rs
@@ -66,7 +66,7 @@ pub struct Metar {
     pub wind_speed_kt: Option<String>,
 
     #[serde(rename = "elevation_m")]
-    pub elevation_m: String,
+    pub elevation_m: Option<String>,
 
     #[serde(rename = "wx_string")]
     pub wx_string: Option<String>,


### PR DESCRIPTION
Some NOAA stations do not include `elevation_m` in their responses, causing deserialization to fail with:

```
error processing data: custom: missing field `elevation_m`
```

This has been breaking data collection since September 2025.

## Changes
- Made `elevation_m` field optional in `xml_observation.rs` (Metar struct)
- Made `elevation_m` field optional in `coordinates.rs` (Station struct)