### PR TITLE
feat: add ARM64 (aarch64-linux) build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,49 @@ jobs:
       - name: Run flake check
         run: nix flake check
 
+  # Build for ARM64 (aarch64-linux) using cross-compilation
+  build-arm64:
+    name: Build ARM64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-platforms = aarch64-linux
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
+          use-flakehub: false
+
+      - name: Install QEMU for ARM64 emulation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          sudo update-binfmts --enable qemu-aarch64
+
+      - name: Build ARM64 packages with Nix
+        run: |
+          nix build .#packages.aarch64-linux.oracle --print-build-logs
+          nix build .#packages.aarch64-linux.daemon --print-build-logs -o result-daemon-arm64
+          echo "ARM64 oracle build complete"
+          file result/bin/oracle
+          echo "ARM64 daemon build complete"
+          file result-daemon-arm64/bin/daemon
+
   # E2E tests (uses pre-built binaries, runs after all other checks pass)
   e2e-test:
     name: E2E Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,9 @@ jobs:
           git commit -m "chore: bump version to ${{ needs.prepare-release.outputs.version }}" || echo "No changes to commit"
           git push origin HEAD:master || echo "No changes to push"
 
-  # Build release binaries using Nix
-  build-release:
-    name: Build Release
+  # Build release binaries for x86_64 using Nix
+  build-release-x86_64:
+    name: Build Release (x86_64)
     runs-on: ubuntu-latest
     needs: prepare-release
     # For real releases, wait for version update; for dry-run, proceed immediately
@@ -262,11 +262,182 @@ jobs:
           path: release/*
           retention-days: 7
 
+  # Build release binaries for ARM64 (aarch64) using Nix cross-compilation
+  build-release-arm64:
+    name: Build Release (ARM64)
+    runs-on: ubuntu-latest
+    needs: prepare-release
+    # For real releases, wait for version update; for dry-run, proceed immediately
+    if: always() && needs.prepare-release.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-platforms = aarch64-linux
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
+          use-flakehub: false
+
+      - name: Install QEMU for ARM64 emulation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          sudo update-binfmts --enable qemu-aarch64
+
+      - name: Build with Nix for ARM64
+        run: |
+          nix build .#packages.aarch64-linux.oracle --print-build-logs
+          nix build .#packages.aarch64-linux.daemon --print-build-logs -o result-daemon
+
+      - name: Create release package
+        run: |
+          VERSION="${{ needs.prepare-release.outputs.version }}"
+          PKG_NAME="noaa-oracle-${VERSION}-aarch64-linux"
+
+          mkdir -p "${PKG_NAME}/bin"
+          mkdir -p "${PKG_NAME}/ui"
+          mkdir -p "${PKG_NAME}/config"
+
+          # Copy Nix-built binaries
+          cp result/bin/oracle "${PKG_NAME}/bin/"
+          cp result-daemon/bin/daemon "${PKG_NAME}/bin/"
+
+          # Copy UI
+          cp -r ui/* "${PKG_NAME}/ui/"
+
+          # Copy and rename config examples to usable defaults
+          cp config/oracle.example.toml "${PKG_NAME}/config/oracle.toml"
+          cp config/daemon.example.toml "${PKG_NAME}/config/daemon.toml"
+
+          # Create setup script for first-time deployment
+          cat > "${PKG_NAME}/setup.sh" << 'EOF'
+          #!/bin/bash
+          set -e
+          SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+          cd "$SCRIPT_DIR"
+
+          echo "NOAA Oracle Setup"
+          echo "================="
+
+          # Create data directories
+          echo "Creating data directories..."
+          mkdir -p weather_data event_data logs data
+
+          # Generate signing key
+          if [ -f "oracle_private_key.pem" ]; then
+              echo "WARNING: oracle_private_key.pem already exists!"
+              echo "Skipping key generation. Delete the file manually if you want to regenerate."
+          else
+              echo "Generating oracle signing key..."
+              openssl ecparam -genkey -name secp256k1 -out oracle_private_key.pem
+              chmod 600 oracle_private_key.pem
+              echo "Private key created: oracle_private_key.pem"
+              echo ""
+              echo "IMPORTANT: Back up this key securely! It is used for DLC attestations."
+              echo "If lost, any events signed with this key cannot be attested."
+          fi
+
+          echo ""
+          echo "Setup complete! You can now run:"
+          echo "  ./run-oracle.sh  - Start the oracle server"
+          echo "  ./run-daemon.sh  - Start the data fetching daemon"
+          EOF
+          chmod +x "${PKG_NAME}/setup.sh"
+
+          # Create run script for oracle
+          cat > "${PKG_NAME}/run-oracle.sh" << 'EOF'
+          #!/bin/bash
+          SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+          cd "$SCRIPT_DIR"
+
+          if [ ! -f "oracle_private_key.pem" ]; then
+              echo "ERROR: oracle_private_key.pem not found!"
+              echo "Run ./setup.sh first to generate the signing key."
+              exit 1
+          fi
+
+          # Create data directories if missing
+          mkdir -p weather_data event_data logs
+
+          export RUST_LOG="${RUST_LOG:-info}"
+          exec ./bin/oracle "$@"
+          EOF
+          chmod +x "${PKG_NAME}/run-oracle.sh"
+
+          # Create run script for daemon
+          cat > "${PKG_NAME}/run-daemon.sh" << 'EOF'
+          #!/bin/bash
+          SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+          cd "$SCRIPT_DIR"
+
+          mkdir -p data logs
+
+          export RUST_LOG="${RUST_LOG:-info}"
+          exec ./bin/daemon "$@"
+          EOF
+          chmod +x "${PKG_NAME}/run-daemon.sh"
+
+          # Create README
+          cat > "${PKG_NAME}/README.txt" << EOF
+          NOAA Oracle v${VERSION} (ARM64/aarch64)
+          =======================================
+
+          Quick Start:
+            1. Run ./setup.sh to initialize (creates directories and signing key)
+            2. Run ./run-oracle.sh to start the oracle server (default port 9800)
+            3. Run ./run-daemon.sh to start fetching NOAA weather data
+
+          Configuration:
+            - Edit config/oracle.toml for oracle settings
+            - Edit config/daemon.toml for daemon settings
+
+          Directories:
+            - ui/           Browser UI files
+            - config/       Configuration files
+            - bin/          Binaries
+            - weather_data/ Downloaded parquet files (created on first run)
+            - event_data/   DLC event database (created on first run)
+
+          Security:
+            - oracle_private_key.pem is your signing key - BACK IT UP!
+            - This key is used for DLC attestations and must be kept secure
+
+          For more info: https://github.com/tee8z/noaa-oracle
+          EOF
+
+          # Create zip
+          mkdir -p release
+          zip -r "release/${PKG_NAME}.zip" "${PKG_NAME}"
+
+          ls -lh release/
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-aarch64-linux
+          path: release/*
+          retention-days: 7
+
   # Create GitHub release (skipped in dry-run)
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [prepare-release, build-release]
+    needs: [prepare-release, build-release-x86_64, build-release-arm64]
     if: needs.prepare-release.outputs.dry_run != 'true'
     permissions:
       contents: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ parquet_derive = "54.0"
 
 
 
+# Suppress warnings from dependencies using non-standard cfg values
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(target_arch, values(\"amdgpu\"))"] }
+
 [profile.release]
 lto = "thin"
 strip = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,3 +14,6 @@ toml.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -48,3 +48,6 @@ serde-xml-rs = "0.6"
 
 # Compression
 async-compression = { version = "0.4", features = ["tokio", "gzip"] }
+
+[lints]
+workspace = true

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -77,3 +77,6 @@ async-trait = "0.1"
 [dev-dependencies]
 tower = "0.5"
 mockall = "0.14"
+
+[lints]
+workspace = true

--- a/deploy/helm/noaa-daemon/Chart.yaml
+++ b/deploy/helm/noaa-daemon/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: noaa-daemon
+description: NOAA weather data fetching daemon
+type: application
+version: 0.1.0
+appVersion: "1.9.2"
+
+home: https://github.com/tee8z/noaa-oracle
+sources:
+  - https://github.com/tee8z/noaa-oracle
+
+maintainers:
+  - name: tee8z
+    email: tee8z@protonmail.com
+
+keywords:
+  - noaa
+  - weather
+  - daemon
+  - data-fetcher

--- a/deploy/helm/noaa-daemon/templates/_helpers.tpl
+++ b/deploy/helm/noaa-daemon/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "noaa-daemon.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "noaa-daemon.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "noaa-daemon.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "noaa-daemon.labels" -}}
+helm.sh/chart: {{ include "noaa-daemon.chart" . }}
+{{ include "noaa-daemon.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "noaa-daemon.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "noaa-daemon.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "noaa-daemon.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "noaa-daemon.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "noaa-daemon.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/deploy/helm/noaa-daemon/templates/cronjob.yaml
+++ b/deploy/helm/noaa-daemon/templates/cronjob.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "noaa-daemon.fullname" . }}
+  labels:
+    {{- include "noaa-daemon.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.job.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          labels:
+            {{- include "noaa-daemon.selectorLabels" . | nindent 12 }}
+        spec:
+          serviceAccountName: {{ include "noaa-daemon.serviceAccountName" . }}
+          restartPolicy: OnFailure
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: RUST_LOG
+                  value: {{ .Values.config.level }}
+                - name: NOAA_DAEMON_BASE_URL
+                  value: {{ .Values.config.baseUrl | quote }}
+                - name: NOAA_DAEMON_DATA_DIR
+                  value: {{ .Values.config.dataDir }}
+                - name: NOAA_DAEMON_USER_AGENT
+                  value: {{ .Values.config.userAgent | quote }}
+                - name: NOAA_DAEMON_REFILL_RATE
+                  value: {{ .Values.config.refillRate | quote }}
+                - name: NOAA_DAEMON_TOKEN_CAPACITY
+                  value: {{ .Values.config.tokenCapacity | quote }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/deploy/helm/noaa-daemon/values.yaml
+++ b/deploy/helm/noaa-daemon/values.yaml
@@ -1,0 +1,60 @@
+# NOAA Daemon Helm Chart Values
+# Weather data fetching daemon
+
+image:
+  repository: ghcr.io/tee8z/noaa-daemon
+  tag: ""  # Defaults to appVersion
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+  automount: true
+
+# CronJob schedule (default: hourly at :05)
+schedule: "5 * * * *"
+
+# Job configuration
+job:
+  backoffLimit: 3
+  activeDeadlineSeconds: 3600
+  ttlSecondsAfterFinished: 86400
+
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 25m
+  limits:
+    memory: 128Mi
+
+podSecurityContext: {}
+securityContext: {}
+
+# Application configuration
+config:
+  # Logging level
+  level: "info"
+  # Oracle server URL to upload data to
+  baseUrl: "http://noaa-oracle.oracle.svc.cluster.local:9800"
+  # Temporary data directory
+  dataDir: /tmp/noaa-daemon
+  # HTTP client settings
+  userAgent: "noaa-oracle-daemon/1.0"
+  refillRate: 15.0
+  tokenCapacity: 3
+
+# Environment variables
+env: {}
+envFrom: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podLabels: {}

--- a/deploy/helm/noaa-oracle/Chart.yaml
+++ b/deploy/helm/noaa-oracle/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: noaa-oracle
+description: Weather data oracle API for DLC-based prediction markets
+type: application
+version: 0.1.0
+appVersion: "1.9.2"
+
+home: https://github.com/tee8z/noaa-oracle
+sources:
+  - https://github.com/tee8z/noaa-oracle
+
+maintainers:
+  - name: tee8z
+    email: tee8z@protonmail.com
+
+keywords:
+  - bitcoin
+  - dlc
+  - weather
+  - oracle
+  - noaa

--- a/deploy/helm/noaa-oracle/templates/_helpers.tpl
+++ b/deploy/helm/noaa-oracle/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "noaa-oracle.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "noaa-oracle.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "noaa-oracle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "noaa-oracle.labels" -}}
+helm.sh/chart: {{ include "noaa-oracle.chart" . }}
+{{ include "noaa-oracle.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "noaa-oracle.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "noaa-oracle.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "noaa-oracle.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "noaa-oracle.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "noaa-oracle.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/deploy/helm/noaa-oracle/templates/configmap.yaml
+++ b/deploy/helm/noaa-oracle/templates/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "noaa-oracle.fullname" . }}
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+data:
+  oracle.toml: |
+    level = {{ .Values.config.level | quote }}
+    host = {{ .Values.config.host | quote }}
+    port = {{ .Values.config.port | quote }}
+    {{- if .Values.config.remoteUrl }}
+    remote_url = {{ .Values.config.remoteUrl | quote }}
+    {{- end }}
+    data_dir = {{ .Values.config.dataDir | quote }}
+    event_db = {{ .Values.config.eventDb | quote }}
+    ui_dir = {{ .Values.config.uiDir | quote }}
+    private_key_path = {{ .Values.config.privateKeyPath | quote }}
+---
+{{- if .Values.litestream.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "noaa-oracle.fullname" . }}-litestream
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+data:
+  litestream.yml: |
+    dbs:
+      - path: {{ .Values.config.eventDb }}/events.duckdb
+        replicas:
+          - type: s3
+            bucket: {{ .Values.litestream.s3Bucket }}
+            path: {{ .Values.litestream.s3Path }}
+            region: {{ .Values.litestream.s3Region }}
+            {{- if .Values.litestream.s3Endpoint }}
+            endpoint: {{ .Values.litestream.s3Endpoint }}
+            force-path-style: {{ .Values.litestream.s3ForcePathStyle }}
+            {{- end }}
+            sync-interval: {{ .Values.litestream.syncInterval }}
+            retention: {{ .Values.litestream.retention }}
+            snapshot-interval: {{ .Values.litestream.snapshotInterval }}
+{{- end }}

--- a/deploy/helm/noaa-oracle/templates/deployment.yaml
+++ b/deploy/helm/noaa-oracle/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "noaa-oracle.fullname" . }}
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "noaa-oracle.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "noaa-oracle.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "noaa-oracle.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.config.level }}
+            - name: NOAA_ORACLE_HOST
+              value: {{ .Values.config.host | quote }}
+            - name: NOAA_ORACLE_PORT
+              value: {{ .Values.config.port | quote }}
+            - name: NOAA_ORACLE_DATA_DIR
+              value: {{ .Values.config.dataDir }}
+            - name: NOAA_ORACLE_EVENT_DB
+              value: {{ .Values.config.eventDb }}
+            - name: NOAA_ORACLE_UI_DIR
+              value: {{ .Values.config.uiDir }}
+            - name: NOAA_ORACLE_PRIVATE_KEY
+              value: {{ .Values.config.privateKeyPath }}
+            {{- if .Values.config.remoteUrl }}
+            - name: NOAA_ORACLE_REMOTE_URL
+              value: {{ .Values.config.remoteUrl | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "noaa-oracle.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/deploy/helm/noaa-oracle/templates/ingress.yaml
+++ b/deploy/helm/noaa-oracle/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "noaa-oracle.fullname" . }}
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "noaa-oracle.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/noaa-oracle/templates/pvc.yaml
+++ b/deploy/helm/noaa-oracle/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "noaa-oracle.fullname" . }}
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/noaa-oracle/templates/service.yaml
+++ b/deploy/helm/noaa-oracle/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "noaa-oracle.fullname" . }}
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "noaa-oracle.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/noaa-oracle/templates/serviceaccount.yaml
+++ b/deploy/helm/noaa-oracle/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "noaa-oracle.serviceAccountName" . }}
+  labels:
+    {{- include "noaa-oracle.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deploy/helm/noaa-oracle/values.yaml
+++ b/deploy/helm/noaa-oracle/values.yaml
@@ -1,0 +1,120 @@
+# NOAA Oracle Helm Chart Values
+# Weather data oracle API for DLC-based prediction markets
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/tee8z/noaa-oracle
+  tag: ""  # Defaults to appVersion
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+  automount: true
+
+service:
+  type: ClusterIP
+  port: 9800
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 50m
+  limits:
+    memory: 256Mi
+
+podSecurityContext: {}
+securityContext: {}
+
+# Health check configuration
+healthCheck:
+  path: /health
+  port: 9800
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# Persistence for weather data and event database
+persistence:
+  enabled: true
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  mountPath: /var/lib/noaa-oracle
+
+# Litestream S3 backup for event database
+litestream:
+  enabled: true
+  image:
+    repository: litestream/litestream
+    tag: "0.3.13"
+  s3Bucket: ""
+  s3Path: "oracle.db"
+  s3Region: "us-east-1"
+  s3Endpoint: ""
+  s3ForcePathStyle: false
+  syncInterval: "10s"
+  retention: "168h"
+  snapshotInterval: "1h"
+
+# Application configuration
+config:
+  # Logging level: trace, debug, info, warn, error
+  level: "info"
+  # Server binding
+  host: "0.0.0.0"
+  port: 9800
+  # Public URL for API responses
+  remoteUrl: ""
+  # Weather data directory
+  dataDir: /var/lib/noaa-oracle/weather
+  # Event database directory (DuckDB)
+  eventDb: /var/lib/noaa-oracle/events
+  # UI static files
+  uiDir: /usr/share/noaa-oracle/ui
+  # Private key path for signing
+  privateKeyPath: /var/lib/noaa-oracle/keys/oracle.pem
+
+# Environment variables
+env: {}
+envFrom: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podLabels: {}
+
+metrics:
+  enabled: false
+  path: /metrics
+  interval: 30s


### PR DESCRIPTION
## Summary

Adds ARM64 (aarch64-linux) build support to enable deployment on cheaper ARM-based servers.

## Changes

### CI Workflow
- Added `build-arm64` job that cross-compiles for ARM64 using QEMU emulation
- Validates ARM64 builds on every PR/push

### Release Workflow
- Added `build-release-arm64` job for ARM64 release artifacts
- Release packages now include both architectures:
  - `noaa-oracle-{VERSION}-x86_64-linux.zip`
  - `noaa-oracle-{VERSION}-aarch64-linux.zip`

### Package Contents
Both packages include:
- `bin/oracle` - REST API server
- `bin/daemon` - Data fetching daemon
- `ui/` - Browser UI files
- `config/` - Configuration files
- Setup and run scripts

## Supported Platforms
- AWS Graviton instances
- Raspberry Pi (64-bit)
- Apple Silicon (via Rosetta or native)
- Any aarch64-linux system

## Technical Details
- Uses QEMU user-mode emulation for cross-compilation on x86_64 GitHub runners
- Nix flake already had ARM64 support configured (DuckDB binaries, architecture detection)
- No code changes required - pure CI/CD updates