### PR TITLE
feat(daemon): make S3 storage runtime configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "version_check",
 ]
@@ -1443,7 +1443,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3053,7 +3053,7 @@ dependencies = [
  "cbc",
  "chacha20",
  "chacha20poly1305",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "instant",
  "negentropy 0.3.1",
  "negentropy 0.4.3",
@@ -3746,7 +3746,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3902,7 +3902,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "http 1.4.0",
  "hyper 1.8.1",
  "parking_lot 0.11.2",
@@ -3943,7 +3943,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -6212,9 +6212,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "ac93432f5b761b22864c774aac244fa5c0fd877678a4c37ebf6cf42208f9c9ec"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,7 @@ parquet_derive = "54.0"
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(target_arch, values(\"amdgpu\"))"] }
 
 [profile.release]
-lto = "thin"
+opt-level = "z"
+codegen-units = 1
+lto = true
 strip = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -10,9 +10,9 @@ description = "NOAA weather data fetcher daemon"
 name = "daemon"
 path = "src/main.rs"
 
-[features]
-default = []
-s3 = ["aws-sdk-s3", "aws-config"]
+
+
+
 
 [dependencies]
 # Internal
@@ -54,8 +54,8 @@ serde-xml-rs = "0.6"
 async-compression = { version = "0.4", features = ["tokio", "gzip"] }
 
 # S3 (optional, behind feature flag)
-aws-sdk-s3 = { version = "1.65", optional = true }
-aws-config = { version = "1.5", features = ["behavior-version-latest"], optional = true }
+aws-sdk-s3 = "1.65"
+aws-config = { version = "1.5", features = ["behavior-version-latest"] }
 
 [lints]
 workspace = true

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,13 +1,13 @@
 mod coordinates;
 mod domains;
 mod parquet_handler;
-#[cfg(feature = "s3")]
+
 mod s3_storage;
 mod utils;
 
 pub use coordinates::*;
 pub use domains::*;
 pub use parquet_handler::*;
-#[cfg(feature = "s3")]
+
 pub use s3_storage::*;
 pub use utils::*;

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1,16 +1,13 @@
 use daemon::{
     create_folder, get_config_info, get_coordinates, save_forecasts, save_observations,
-    send_parquet_files, setup_logger, subfolder_exists, Cli, ForecastService, ObservationService,
-    RateLimiter, XmlFetcher,
+    send_parquet_files, setup_logger, subfolder_exists, upload_to_s3, Cli, ForecastService,
+    ObservationService, RateLimiter, S3Storage, XmlFetcher,
 };
 use slog::{debug, error, info, Logger};
 use std::{sync::Arc, time::Duration};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::sync::Mutex;
 use tokio::time::interval;
-
-#[cfg(feature = "s3")]
-use daemon::{upload_to_s3, S3Storage};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -22,12 +19,13 @@ async fn main() -> Result<(), anyhow::Error> {
     info!(logger, "  Data dir: {}", cli.data_dir());
     info!(logger, "  Fetch interval: {} seconds", cli.sleep_interval());
 
-    #[cfg(feature = "s3")]
-    if cli.s3_bucket.is_some() {
-        info!(logger, "  S3 bucket: {}", cli.s3_bucket.as_ref().unwrap());
+    if let Some(ref bucket) = cli.s3_bucket {
+        info!(logger, "  S3 bucket: {}", bucket);
         if let Some(ref endpoint) = cli.s3_endpoint {
             info!(logger, "  S3 endpoint: {}", endpoint);
         }
+    } else {
+        info!(logger, "  S3 disabled, using local storage only");
     }
 
     let rate_limiter = Arc::new(Mutex::new(RateLimiter::new(
@@ -35,7 +33,6 @@ async fn main() -> Result<(), anyhow::Error> {
         cli.refill_rate(),
     )));
 
-    #[cfg(feature = "s3")]
     let s3_storage = if let Some(ref bucket) = cli.s3_bucket {
         Some(
             S3Storage::new(bucket.clone(), cli.s3_endpoint.clone(), logger.clone())
@@ -46,16 +43,11 @@ async fn main() -> Result<(), anyhow::Error> {
         None
     };
 
-    #[cfg(feature = "s3")]
     process_weather_data_hourly(cli, logger, Arc::clone(&rate_limiter), s3_storage).await;
-
-    #[cfg(not(feature = "s3"))]
-    process_weather_data_hourly(cli, logger, Arc::clone(&rate_limiter)).await;
 
     Ok(())
 }
 
-#[cfg(feature = "s3")]
 async fn process_weather_data_hourly(
     cli: Cli,
     logger: Logger,
@@ -81,32 +73,6 @@ async fn process_weather_data_hourly(
     }
 }
 
-#[cfg(not(feature = "s3"))]
-async fn process_weather_data_hourly(
-    cli: Cli,
-    logger: Logger,
-    rate_limit: Arc<Mutex<RateLimiter>>,
-) {
-    let sleep_between_checks = cli.sleep_interval();
-    info!(
-        logger,
-        "Wait time between data pulls: {} seconds", sleep_between_checks
-    );
-
-    let mut check_channel_interval = interval(Duration::from_secs(sleep_between_checks));
-    loop {
-        tokio::select! {
-            _ = check_channel_interval.tick() => {
-                match process_data(cli.clone(), logger.clone(), rate_limit.clone()).await {
-                    Ok(_) => info!(logger, "Finished processing data, waiting {} seconds for next run", sleep_between_checks),
-                    Err(err) => error!(&logger, "Error processing data: {}", err)
-                }
-            }
-        }
-    }
-}
-
-#[cfg(feature = "s3")]
 async fn process_data(
     cli: Cli,
     logger: Logger,
@@ -170,58 +136,5 @@ async fn process_data(
         send_parquet_files(&cli, logger_cpy, observation_parquet, forecast_parquet).await?;
     }
 
-    Ok(())
-}
-
-#[cfg(not(feature = "s3"))]
-async fn process_data(
-    cli: Cli,
-    logger: Logger,
-    rate_limiter: Arc<Mutex<RateLimiter>>,
-) -> Result<(), anyhow::Error> {
-    let logger_cpy = &logger.clone();
-    let fetcher = Arc::new(XmlFetcher::new(
-        logger.clone(),
-        cli.user_agent(),
-        rate_limiter,
-    ));
-
-    let city_weather_coordinates = get_coordinates(fetcher.clone()).await?;
-    debug!(logger_cpy, "coordinates: {}", city_weather_coordinates);
-
-    let forecast_service = ForecastService::new(logger.clone(), fetcher.clone());
-    let forecasts = forecast_service
-        .get_forecasts(&city_weather_coordinates)
-        .await?;
-    debug!(logger_cpy, "forecasts count: {}", forecasts.len());
-
-    let observation_service = ObservationService::new(logger, fetcher);
-    let observations = observation_service
-        .get_observations(&city_weather_coordinates)
-        .await?;
-    debug!(logger_cpy, "observations count: {:?}", observations.len());
-
-    let current_utc_time: String = OffsetDateTime::now_utc().format(&Rfc3339)?;
-    let root_path = cli.data_dir();
-    create_folder(&root_path, logger_cpy);
-
-    let current_date = OffsetDateTime::now_utc().date();
-    let subfolder = format!("{}/{}", root_path, current_date);
-    if !subfolder_exists(&subfolder) {
-        create_folder(&subfolder, logger_cpy)
-    }
-
-    let forecast_parquet = save_forecasts(
-        forecasts,
-        &subfolder,
-        format!("{}_{}", "forecasts", current_utc_time),
-    );
-    let observation_parquet = save_observations(
-        observations,
-        &subfolder,
-        format!("{}_{}", "observations", current_utc_time),
-    );
-
-    send_parquet_files(&cli, logger_cpy, observation_parquet, forecast_parquet).await?;
     Ok(())
 }

--- a/crates/daemon/src/parquet_handler.rs
+++ b/crates/daemon/src/parquet_handler.rs
@@ -1,7 +1,4 @@
-use std::{fs::File, sync::Arc};
-
-#[cfg(feature = "s3")]
-use std::path::Path;
+use std::{fs::File, path::Path, sync::Arc};
 
 use anyhow::{anyhow, Error};
 use parquet::{
@@ -15,10 +12,8 @@ use tokio_util::codec::{BytesCodec, FramedRead};
 
 use crate::{
     create_forecast_schema, create_observation_schema, get_full_path, Cli, Forecast, Observation,
+    S3Storage,
 };
-
-#[cfg(feature = "s3")]
-use crate::S3Storage;
 
 pub fn save_observations(
     observations: Vec<Observation>,
@@ -62,7 +57,6 @@ pub fn save_forecasts(forecast: Vec<Forecast>, root_path: &str, file_name: Strin
     full_name
 }
 
-#[cfg(feature = "s3")]
 pub async fn upload_to_s3(
     s3: &S3Storage,
     logger: &Logger,

--- a/crates/daemon/src/s3_storage.rs
+++ b/crates/daemon/src/s3_storage.rs
@@ -1,18 +1,13 @@
-#[cfg(feature = "s3")]
 use aws_sdk_s3::Client;
-#[cfg(feature = "s3")]
 use slog::{error, info, Logger};
-#[cfg(feature = "s3")]
 use std::path::Path;
 
-#[cfg(feature = "s3")]
 pub struct S3Storage {
     client: Client,
     bucket: String,
     logger: Logger,
 }
 
-#[cfg(feature = "s3")]
 impl S3Storage {
     pub async fn new(
         bucket: String,
@@ -78,21 +73,5 @@ impl S3Storage {
     ) -> Result<(), anyhow::Error> {
         let s3_key = format!("weather_data/{}/{}", date_folder, filename);
         self.upload_file(local_path, &s3_key).await
-    }
-}
-
-#[cfg(not(feature = "s3"))]
-pub struct S3Storage;
-
-#[cfg(not(feature = "s3"))]
-impl S3Storage {
-    pub async fn new(
-        _bucket: String,
-        _endpoint: Option<String>,
-        _logger: slog::Logger,
-    ) -> Result<Self, anyhow::Error> {
-        Err(anyhow::anyhow!(
-            "S3 storage requires the 's3' feature to be enabled"
-        ))
     }
 }

--- a/deploy/helm/noaa-oracle/templates/secret.yaml
+++ b/deploy/helm/noaa-oracle/templates/secret.yaml
@@ -6,11 +6,14 @@ metadata:
   labels:
     {{- include "noaa-oracle.labels" . | nindent 4 }}
 type: Opaque
-data:
+stringData:
   {{- if .Values.secrets.privateKey.generate }}
-  {{/* Generate a random 32-byte hex key for local dev/testing */}}
-  oracle.pem: {{ randAlphaNum 64 | b64enc | quote }}
+  {{/* Generate a random 32-byte key in PEM format for local dev/testing */}}
+  oracle.pem: |
+    -----BEGIN EC PRIVATE KEY-----
+    {{ randBytes 32 | b64enc }}
+    -----END EC PRIVATE KEY-----
   {{- else }}
-  oracle.pem: {{ .Values.secrets.privateKey.value | b64enc | quote }}
+  oracle.pem: {{ .Values.secrets.privateKey.value | quote }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/noaa-oracle/templates/secret.yaml
+++ b/deploy/helm/noaa-oracle/templates/secret.yaml
@@ -7,13 +7,5 @@ metadata:
     {{- include "noaa-oracle.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- if .Values.secrets.privateKey.generate }}
-  {{/* Generate a random 32-byte key in PEM format for local dev/testing */}}
-  oracle.pem: |
-    -----BEGIN EC PRIVATE KEY-----
-    {{ randBytes 32 | b64enc }}
-    -----END EC PRIVATE KEY-----
-  {{- else }}
   oracle.pem: {{ .Values.secrets.privateKey.value | quote }}
-  {{- end }}
 {{- end }}

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
           inherit system overlays;
         };
 
-        # Use stable Rust (1.85 required for duckdb 1.4 and arrow 56)
-        rustToolchain = pkgs.rust-bin.stable."1.85.0".default.override {
+        # Use latest stable Rust
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-analyzer" ];
         };
 


### PR DESCRIPTION
## Summary
Make S3 storage a runtime configuration option instead of a compile-time feature flag.

## Changes
- Remove `#[cfg(feature = "s3")]` conditionals from all daemon source files
- Make `aws-sdk-s3` and `aws-config` non-optional dependencies
- S3 storage is now enabled at runtime via `NOAA_DAEMON_S3_BUCKET` env var
- Falls back to local file storage + HTTP upload when S3 is not configured

