### PR TITLE
fix: support EC2 instance profile credentials for S3

### DIFF
--- a/deploy/helm/noaa-daemon/templates/cronjob.yaml
+++ b/deploy/helm/noaa-daemon/templates/cronjob.yaml
@@ -54,6 +54,8 @@ spec:
                 - name: NOAA_DAEMON_S3_ENDPOINT
                   value: {{ .Values.s3.endpoint | quote }}
                 {{- end }}
+                {{/* Only inject explicit credentials if provided; otherwise use instance profile */}}
+                {{- if and .Values.s3.accessKeyId .Values.s3.secretAccessKey }}
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:
@@ -64,6 +66,7 @@ spec:
                     secretKeyRef:
                       name: {{ include "noaa-daemon.fullname" . }}-s3
                       key: secret-access-key
+                {{- end }}
                 {{- end }}
               {{- if .Values.devMode.enabled }}
               volumeMounts:

--- a/deploy/helm/noaa-daemon/templates/s3-secret.yaml
+++ b/deploy/helm/noaa-daemon/templates/s3-secret.yaml
@@ -1,4 +1,9 @@
-{{- if .Values.s3.enabled }}
+{{/*
+S3 credentials secret - only created when explicit credentials are provided.
+When not provided, the daemon uses the default AWS credential chain
+(EC2 instance profile, ECS task role, etc.)
+*/}}
+{{- if and .Values.s3.enabled .Values.s3.accessKeyId .Values.s3.secretAccessKey }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Problem
The daemon helm chart was always creating an S3 credentials secret and injecting `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` environment variables, even when no credentials were provided in values. This resulted in empty credentials being injected, which broke the AWS SDK's ability to fall back to EC2 instance profile credentials (IMDS).

## Solution
- Only create the S3 secret when explicit credentials (`s3.accessKeyId` and `s3.secretAccessKey`) are provided
- Only inject the AWS credential env vars when the secret exists
- When no credentials are provided, the AWS SDK automatically uses the default credential chain (EC2 instance profile, ECS task role, etc.)

## Impact
This allows the daemon to work in staging/production environments that use EC2 instance profiles for S3 access, while still supporting explicit credentials for local development with moto/localstack.

## Testing
- Local dev: Set `s3.accessKeyId` and `s3.secretAccessKey` in values for moto
- Staging/Prod: Leave credentials empty, daemon uses EC2 instance profile