### PR TITLE
feat: accurate rain calculation with snow ratio and ice

### DIFF
--- a/crates/daemon/src/domains/forecasts/xml_forecast.rs
+++ b/crates/daemon/src/domains/forecasts/xml_forecast.rs
@@ -204,6 +204,9 @@ pub enum Type {
     #[serde(rename = "snow")]
     Snow,
 
+    #[serde(rename = "ice")]
+    Ice,
+
     #[serde(rename = "ratio of snow accumulation to its melted liquid equivalent")]
     SnowRatio,
 }
@@ -231,6 +234,9 @@ pub enum Name {
 
     #[serde(rename = "Snow Ratio")]
     SnowRatio,
+
+    #[serde(rename = "Ice Accumulation")]
+    IceAccumulation,
 
     #[serde(rename = "12 Hourly Probability of Precipitation")]
     The12HourlyProbabilityOfPrecipitation,

--- a/crates/oracle/tests/api/attestation.rs
+++ b/crates/oracle/tests/api/attestation.rs
@@ -608,6 +608,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
         Forecast {
             station_id: String::from("KSAW"),
@@ -624,6 +625,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
     ]
 }

--- a/crates/oracle/tests/api/etl_workflow.rs
+++ b/crates/oracle/tests/api/etl_workflow.rs
@@ -408,6 +408,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
         Forecast {
             station_id: String::from("KSAW"),
@@ -424,6 +425,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
         Forecast {
             station_id: String::from("PAPG"),
@@ -440,6 +442,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
         Forecast {
             station_id: String::from("KWMC"),
@@ -456,6 +459,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
     ]
 }

--- a/crates/oracle/tests/api/ui_fragments.rs
+++ b/crates/oracle/tests/api/ui_fragments.rs
@@ -264,6 +264,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
         Forecast {
             station_id: String::from("KORD"),
@@ -280,6 +281,7 @@ fn mock_forecast_data() -> Vec<Forecast> {
             precip_chance: None,
             rain_amt: None,
             snow_amt: None,
+            ice_amt: None,
         },
     ]
 }

--- a/deploy/helm/noaa-oracle/templates/configmap.yaml
+++ b/deploy/helm/noaa-oracle/templates/configmap.yaml
@@ -26,9 +26,6 @@ metadata:
     {{- include "noaa-oracle.labels" . | nindent 4 }}
 data:
   litestream.yml: |
-    {{- if .Values.litestream.httpServer.enabled }}
-    addr: ":{{ .Values.litestream.httpServer.port }}"
-    {{- end }}
     dbs:
       - path: {{ .Values.config.eventDb }}/events.sqlite
         replicas:

--- a/deploy/helm/noaa-oracle/templates/deployment.yaml
+++ b/deploy/helm/noaa-oracle/templates/deployment.yaml
@@ -113,12 +113,6 @@ spec:
         - name: litestream
           image: "{{ .Values.litestream.image.repository }}:{{ .Values.litestream.image.tag }}"
           args: ["replicate"]
-          {{- if .Values.litestream.httpServer.enabled }}
-          ports:
-            - name: litestream-http
-              containerPort: {{ .Values.litestream.httpServer.port }}
-              protocol: TCP
-          {{- end }}
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}

--- a/deploy/helm/noaa-oracle/templates/service.yaml
+++ b/deploy/helm/noaa-oracle/templates/service.yaml
@@ -11,14 +11,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if and .Values.litestream.enabled .Values.litestream.httpServer.enabled }}
-    - port: {{ .Values.litestream.httpServer.port }}
-      targetPort: litestream-http
-      protocol: TCP
-      name: litestream
-      {{- if .Values.litestream.httpServer.nodePort }}
-      nodePort: {{ .Values.litestream.httpServer.nodePort }}
-      {{- end }}
-    {{- end }}
   selector:
     {{- include "noaa-oracle.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/noaa-oracle/values.yaml
+++ b/deploy/helm/noaa-oracle/values.yaml
@@ -93,10 +93,6 @@ litestream:
     name: ""
     key: "encryption-key"
   useIAMRole: false
-  # HTTP server for live read replicas (used by Grafana for real-time SQLite access)
-  httpServer:
-    enabled: false
-    port: 9090
 
 # Application configuration
 config:


### PR DESCRIPTION
## Summary
Fixes precipitation display by calculating actual rain amount instead of showing QPF (total liquid equivalent).

## Changes
- Add `snow_ratio` from NOAA (snow-to-liquid ratio, typically 10-20:1)
- Add `ice_amt` (freezing rain/ice accumulation)
- Fix wind speed not being stored (time range matching bug)

## Rain Calculation
```
rain = QPF - (snow_amt / snow_ratio) - ice_amt
```

QPF includes liquid equivalent of all precipitation (rain + melted snow + ice). We subtract snow's liquid equivalent and ice to get actual rain.

**References:**
- [QPF Definition](https://www.drought.gov/data-maps-tools/quantitative-precipitation-forecast-qpf)
- [NOAA Parameters](https://graphical.weather.gov/xml/docs/elementInputNames.php)